### PR TITLE
preparing ciutils to tag 2.20.1 on dockerhub

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - master
+    tags:
+      - '*'
   pull_request:
     branches:
       - master
+    tags:
+      - '*'
 
 env:
   HAS_SECRETS: ${{ secrets.HAS_SECRETS }}

--- a/ci/config.yaml
+++ b/ci/config.yaml
@@ -15,6 +15,9 @@ version:
   branch_to_version_re:
     - from: master
       to: latest
+  tag_to_version_re:
+    - from: 2.20.1
+      to: 2.20.1
 
 publish:
   pypi:

--- a/ci/config.yaml
+++ b/ci/config.yaml
@@ -15,10 +15,7 @@ version:
   branch_to_version_re:
     - from: master
       to: latest
-  tag_to_version_re:
-    - from: 2.20.1
-      to: 2.20.1
-
+      
 publish:
   pypi:
     packages: []


### PR DESCRIPTION
The only tag we have on dockerhub for the recent builds is `latest`
We also need to have the version
