### PR TITLE
Enable parametrization with environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,15 +60,15 @@ RUN curl -L https://sourceforge.net/projects/geoserver/files/GeoServer/${GEOSERV
 # Install native JAI  https://geoserver.geo-solutions.it/multidim/install_run/jai_io_install.html
 RUN wget http://download.java.net/media/jai/builds/release/1_1_3/jai-1_1_3-lib-linux-amd64.tar.gz && \
     tar xzf jai-1_1_3-lib-linux-amd64.tar.gz -C /tmp && \
-    mv -v /tmp/jai-1_1_3/lib/* $JETTY_HOME/lib/ext/ && \
+    mv -v /tmp/jai-1_1_3/lib/* $JETTY_BASE/lib/ext/ && \
     rm -r /tmp/jai-1_1_3 jai-1_1_3-lib-linux-amd64.tar.gz
 RUN wget http://download.java.net/media/jai-imageio/builds/release/1.1/jai_imageio-1_1-lib-linux-amd64.tar.gz && \
     tar xzf jai_imageio-1_1-lib-linux-amd64.tar.gz -C /tmp && \
-    mv -v /tmp/jai_imageio-1_1/lib/* $JETTY_HOME/lib/ext/ && \
+    mv -v /tmp/jai_imageio-1_1/lib/* $JETTY_BASE/lib/ext/ && \
     rm -r /tmp/jai_imageio-1_1 jai_imageio-1_1-lib-linux-amd64.tar.gz
 
 # JVM var java.library.path will be based on this env var. so GS will search native libs there.
-ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/libjpeg-turbo/lib64/:$JETTY_HOME/lib/ext/"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/libjpeg-turbo/lib64/:$JETTY_BASE/lib/ext/"
 
 # the servlets jetty module contains CORS filters
 RUN java -jar "$JETTY_HOME/start.jar" --add-module=servlets
@@ -78,6 +78,7 @@ ENV JAVA_OPTIONS "-Xms$XMS -Xmx$XMX \
  -DGEOSERVER_DATA_DIR=/mnt/geoserver_datadir \
  -DGEOWEBCACHE_CACHE_DIR=/mnt/geoserver_tiles \
  -DENABLE_JSONP=true \
+ -DALLOW_ENV_PARAMETRIZATION=true \
  -Dorg.geotools.coverage.jaiext.enabled=true \
  -XX:SoftRefLRUPolicyMSPerMB=36000 \
  -XX:-UsePerfData "

--- a/acceptance_tests/Pipfile
+++ b/acceptance_tests/Pipfile
@@ -8,7 +8,7 @@ pytest = "==6.2.5"
 c2cwsgiutils = "==4.1.4"
 boltons = "==21.0.0"
 netifaces = "==0.11.0"
-requests = "==2.26.0"
+requests = "==2.27.1"
 lxml = "==4.7.1"
 
 [dev-packages]

--- a/ci/config.yaml
+++ b/ci/config.yaml
@@ -3,6 +3,7 @@
 
 checks:
   required_workflows: False
+  black: False
   black_config: False
   versions: False
   codespell: False


### PR DESCRIPTION
This allows to use environment variables for e.g. database connection variables:

```bash
docker run --env GEOSERVER_DB_HOST=localhost geoserver:latest
```

The variable `${GEOSERVER_DB_HOST}` can then be used for parametrization in the webui or directly in the XML files.

Side note: is it possible there was a mix up between `$JETTY_BASE` and `$JETTY_HOME` in the Dockerfile? I had to make some changes to build the image otherwise I got the error:

```bash
mv: target '/usr/local/jetty/lib/ext/' is not a directory
The command '/bin/sh -c wget http://download.java.net/media/jai-imageio/builds/release/1.1/jai_imageio-1_1-lib-linux-amd64.tar.gz &&     tar xzf jai_imageio-1_1-lib-linux-amd64.tar.gz -C /tmp &&     mv -v /tmp/jai_imageio-1_1/lib/* $JETTY_HOME/lib/ext/ &&     rm -r /tmp/jai_imageio-1_1 jai_imageio-1_1-lib-linux-amd64.tar.gz' returned a non-zero code: 1
make: *** [Makefile:14: build] Error 1
```