### PR TITLE
chore: bump to GeoServer 2.26.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM jetty:10-jre11 as builder
+FROM jetty:10-jre11 AS builder
 MAINTAINER Camptocamp "info@camptocamp.com"
 
-# Latest stable as of 7th of march 2023
-ENV GEOSERVER_VERSION 2.25
-ENV GEOSERVER_MINOR_VERSION 2
+ENV GEOSERVER_VERSION 2.26
+ENV GEOSERVER_MINOR_VERSION 1
 ENV XMS=1536M XMX=8G
 
 USER root
@@ -91,3 +90,6 @@ USER root
 RUN chown -R jetty:jetty /mnt/geoserver_datadir/*
 
 VOLUME [ "/mnt/geoserver_datadir", "/mnt/geoserver_geodata", "/mnt/geoserver_tiles", "/tmp" ]
+
+# downgrade to jetty user
+USER jetty

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM jetty:10-jre11 AS builder
-MAINTAINER Camptocamp "info@camptocamp.com"
+LABEL org.opencontainers.image.authors="Camptocamp <info@camptocamp.com>"
 
 ENV GEOSERVER_VERSION 2.26
 ENV GEOSERVER_MINOR_VERSION 1

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ build:
 		docker build --tag=$(DOCKER_IMAGE):$(DOCKER_TAG) --no-cache .
 
 acceptance: build
-	(cd acceptance_tests/ && docker-compose down)
-	(cd acceptance_tests/ && docker-compose build)
-	(cd acceptance_tests/ && docker-compose up -d)
-	(cd acceptance_tests/ && docker-compose exec -T acceptance py.test -vv --color=yes --junitxml /tmp/junitxml/results.xml)
-	(cd acceptance_tests/ && docker-compose down -t1)
+	(cd acceptance_tests/ && docker compose down)
+	(cd acceptance_tests/ && docker compose build)
+	(cd acceptance_tests/ && docker compose up -d)
+	(cd acceptance_tests/ && docker compose exec -T acceptance py.test -vv --color=yes --junitxml /tmp/junitxml/results.xml)
+	(cd acceptance_tests/ && docker compose down -t1)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Docker image for GeoServer
 
-A docker image that runs GeoServer version 2.25.2
+A docker image that runs GeoServer version 2.26.1
 
 ## To run
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,6 +9,8 @@
 | 2.22.2    | Best effort     | 07/03/2023                                                    |
 | 2.24.1    | Best effort     | 27/11/2023                                                    |
 | 2.25.2    | Best effort     | 18/06/2024                                                    |
+| 2.26.1    | Best effort     | 18/11/2024                                                    |
+
 
 
 [Reporting Upstream Vulnerability](http://geoserver.org/issues/)


### PR DESCRIPTION
Also includes some fixes in the Dockerfile ("AS" uppercased, downgrading back to USER jetty at the end of the dockerfile).